### PR TITLE
Passing closure for `switch` type

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -286,7 +286,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -317,7 +317,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -286,7 +286,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -317,7 +317,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -28,6 +28,7 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
         TPTweakEntry.trackingTimeout.register()
         TPTweakEntry.trackingHistory.register()
         TPTweakEntry.trackingServerLocation.register()
+        TPTweakEntry.trackingUsingLocale.register()
         TPTweakEntry.changeLanguage.register()
 
         let viewController = ViewController()

--- a/Example/Example/TPTweakEntry+Extension.swift
+++ b/Example/Example/TPTweakEntry+Extension.swift
@@ -54,6 +54,20 @@ extension TPTweakEntry {
         type: .strings(item: ["US", "UK", "SG"], selected: "SG")
     )
     
+    static let trackingUsingLocale = TPTweakEntry(
+        category: "Tracking",
+        section: "Locale",
+        cell: "Using Locale",
+        footer: "Enabled this to let the tracker send data about your locale",
+        type: .switch(defaultValue: false, closure: { isUsingLocale in
+            if isUsingLocale {
+                UserDefaults.standard.set(Locale.current.identifier, forKey: "tracker_locale")
+            } else {
+                UserDefaults.standard.removeObject(forKey: "tracker_locale")
+            }
+        })
+    )
+    
     static let changeLanguage = TPTweakEntry(
         category: "Apperance",
         section: "Language",

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -91,6 +91,9 @@ class ViewController: UIViewController {
         Tracking status: \(TPTweakEntry.enableTracking.getValue(Bool.self))
         Tracking server location: \(TPTweakEntry.trackingServerLocation.getValue(String.self))
         Tracking max timeout: \(TPTweakEntry.trackingTimeout.getValue(Int.self))
+        
+        Tracking locale is active: \(TPTweakEntry.trackingUsingLocale.getValue(Bool.self))
+        Tracking locale identifer: \((UserDefaults.standard.value(forKey: "tracker_locale") as? String) ?? "no locale")
         """
     }
 }

--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ Using this type, you can create a cell with a UISwitch to enable/disable an opti
 .switch(defaultValue: true)
 ```
 
+
+You could also add `closure: ((Bool) -> Void)?` that will run **after** the value is changed.
+
+```swift
+.switch(defaultValue: true, closure: { isToggledOn in
+    UserDefaults.standard.set(isToggledOn, forKey: "myvalue_is_on")
+})
+```
+
 **Strings**
 
 ![](assets/strings.png)

--- a/Sources/TPTweak/TPTweakEntry.swift
+++ b/Sources/TPTweak/TPTweakEntry.swift
@@ -18,7 +18,7 @@ import Foundation
  Entry type, pick your poison
  */
 public enum TPTweakEntryType {
-    case `switch`(defaultValue: Bool)
+    case `switch`(defaultValue: Bool, closure: ((Bool) -> Void)? = nil)
     case action(() -> Void)
     case strings(item: [String], selected: String)
     case numbers(item: [Double], selected: Double)

--- a/Sources/TPTweak/TPTweakPickerViewController.swift
+++ b/Sources/TPTweak/TPTweakPickerViewController.swift
@@ -152,12 +152,13 @@ extension TPTweakPickerViewController: UITableViewDataSource, UITableViewDelegat
         switch cellData.type {
         case let .action(closure):
             closure()
-        case .switch:
+        case let .switch(_, closure):
             var value = TPTweakStore.read(type: Bool.self, identifier: cellData.identifer) ?? false
             value.toggle()
 
             TPTweakStore.set(value, identifier: cellData.identifer)
             tableView.reloadRows(at: [indexPath], with: .automatic) // to update cell value after action
+            closure?(value)
         case let .numbers(item, defaultValue):
             let viewController = TPTweakOptionsViewController(
                 title: cellData.name,

--- a/Sources/TPTweak/TPTweakStore.swift
+++ b/Sources/TPTweak/TPTweakStore.swift
@@ -120,7 +120,7 @@ public enum TPTweakStore {
         /// indicate no value exist before on provider
         if environment.provider().data(forKey: identifier) == nil {
             switch entry.type {
-            case let .switch(defaultValue):
+            case let .switch(defaultValue, _):
                 set(defaultValue, identifier: identifier)
             case let .numbers(_, defaultValue):
                 set(defaultValue, identifier: identifier)


### PR DESCRIPTION
## Preview
https://github.com/tokopedia/ios-tptweak/assets/50097952/6e2f41bc-8368-4dd9-8c98-a92f0ff1f4e0


## What is it?
For `switch` type, I add a capability to add an action **after** the switch is toggled.
The closure will have a boolean value, that indicates the switch state after the user clicks on it.

The advantage compared to using `action` type are we still have the switch to indicate to the user about the option status (is it on or off) without opening another page or showing a dialog.