### PR TITLE
Expose environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,36 +9,16 @@ on:
       - '*'
 
 jobs:
-  build-monterey:
-    strategy:
-      matrix:
-        xcode:
-          - '13.1'
-          - '13.2.1'
-          - '13.3.1'
-          - '13.4.1'    
-          - '14.0'         
-    runs-on: macos-12
+  build-latest:
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Select Xcode ${{ matrix.xcode }}
-        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
       - name: Run Build
         run: swift build
-  unit_test-monterey:
-    strategy:
-      matrix:
-        xcode:
-          - '13.1'
-          - '13.2.1'
-          - '13.3.1'
-          - '13.4.1'    
-          - '14.0'     
-    runs-on: macos-12
+  unit_test-latest:
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Select Xcode ${{ matrix.xcode }}
-        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
       - name: Run tests
         run: swift test --enable-test-discovery --enable-code-coverage | xcpretty
   build-ventura:

--- a/.github/workflows/podspec.yml
+++ b/.github/workflows/podspec.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   linting:      
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
       - name: Install Cocoapods

--- a/README.md
+++ b/README.md
@@ -176,6 +176,26 @@ if you want to set the value manually programmatically
 TPTweakEntry.enableTracking.setValue(true)
 ```
 
+## Use custom UserDefaults provider
+you can change the UserDefaults with modifying the TPTweakStore environment
+```swift
+TPTweakStore.environment.provider = {
+    UserDefaults(suiteName: "group.com.example")
+}
+```
+
+## Use custom isDebugMode logic
+you can configure when to enable TPTweak value by adjusting TPTweakStore environment
+```swift
+TPTweakStore.environment.isDebugMode = {
+    #if DEBUG || IN_HOUSE 
+        return true
+    #else
+        return false
+    #endif
+}
+```
+
 # License
 ```
  Copyright 2022-2024 Tokopedia. All rights reserved.

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ TPTweakStore.environment.provider = {
 ## Use custom isDebugMode logic
 you can configure when to enable TPTweak value by adjusting TPTweakStore environment
 ```swift
+
 TPTweakStore.environment.isDebugMode = {
     #if DEBUG || IN_HOUSE 
         return true

--- a/README.md
+++ b/README.md
@@ -212,3 +212,5 @@ TPTweakStore.environment.isDebugMode = {
  See the License for the specific language governing permissions and
  limitations under the License.
 ```
+
+

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ TPTweakEntry.enableTracking.setValue(true)
 you can change the UserDefaults with modifying the TPTweakStore environment
 ```swift
 TPTweakStore.environment.provider = {
-    UserDefaults(suiteName: "group.com.example")
+    UserDefaults(suiteName: "group.com.example")!
 }
 ```
 

--- a/Sources/TPTweak/TPTweakStore.swift
+++ b/Sources/TPTweak/TPTweakStore.swift
@@ -97,7 +97,7 @@ internal typealias TPTweak = TPTweakStore
  */
 public enum TPTweakStore {
     /// all side effect logic, also for unit testing
-    internal static var environment: TPTweakStoreEnvironment = .live
+    public static var environment: TPTweakStoreEnvironment = .live
     internal static var entries: [String: TPTweakEntry] = [:]
 
     // MARK: - Interface
@@ -253,14 +253,14 @@ extension TPTweakEntry {
     }
 }
 
-internal struct TPTweakStoreEnvironment {
-    internal var isDebugMode: () -> Bool
-    internal var provider: () -> UserDefaults
+public struct TPTweakStoreEnvironment {
+    public var isDebugMode: () -> Bool
+    public var provider: () -> UserDefaults
 
-    internal static var live: Self {
+    public static var live: Self {
         TPTweakStoreEnvironment(
             isDebugMode: {
-                #if USE_DEVTOOLS
+                #if TPTWEAK_ENABLE_RELEASE_MODE
                     return true
                 #elseif DEBUG
                     return true

--- a/TPTweak.podspec
+++ b/TPTweak.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name             = "TPTweak"
-  spec.version          = "2.0.2"
+  spec.version          = "2.1.0"
   spec.summary          = "TPTweak is a debugging tool to help adjust your iOS app on the fly without recompile"
 
   spec.license          = { :type => "Apache 2.0", :file => "LICENSE.md" }
@@ -18,7 +18,7 @@ Pod::Spec.new do |spec|
   end
 
   spec.subspec 'DevTools' do |ss|
-    ss.compiler_flags = "-DUSE_DEVTOOLS"
+    ss.compiler_flags = "-DTPTWEAK_ENABLE_RELEASE_MODE"
     ss.source_files = "Sources/TPTweak/"
   end
 end


### PR DESCRIPTION
add ability to set custom case for isDebugMode and userdefault provider

## Use custom UserDefaults provider
you can change the UserDefaults with modifying the TPTweakStore environment
```swift
TPTweakStore.environment.provider = {
    UserDefaults(suiteName: "group.com.example")!
}
```

## Use custom isDebugMode logic
you can configure when to enable TPTweak value by adjusting TPTweakStore environment
```swift
TPTweakStore.environment.isDebugMode = {
    #if DEBUG || IN_HOUSE 
        return true
    #else
        return false
    #endif
}
```