### PR TITLE
fix: flatten tweak entries in search to show all options

### DIFF
--- a/Sources/TPTweak/TPTweakViewController.swift
+++ b/Sources/TPTweak/TPTweakViewController.swift
@@ -655,7 +655,7 @@ extension TPTweakViewController: UISearchControllerDelegate {
             guard let self else { return }
             let sections = self.convertEntriesToPickerSection(
                 entries: TPTweakStore.entries.map(\.value),
-                flatten: false
+                flatten: true
             )
             
             DispatchQueue.main.async {


### PR DESCRIPTION
Search results now include all tweak entries by flattening the sections, improving discoverability of tweaks when searching