### PR TITLE
feat(tweak): add option to always show search bar

### DIFF
--- a/Sources/TPTweak/TPTweakEntry.swift
+++ b/Sources/TPTweak/TPTweakEntry.swift
@@ -166,6 +166,16 @@ extension TPTweakEntry {
             type: TPTweakEntryType.switch(defaultValue: false, completion: nil)
         )
     }
+
+    public static var _internal_tptweak_always_show_search_bar: TPTweakEntry {
+        TPTweakEntry(
+            category: "_tptweak",
+            section: "Layout",
+            cell: "Always Show Search Bar",
+            footer: "",
+            type: TPTweakEntryType.switch(defaultValue: false, completion: nil)
+        )
+    }
 }
 
 // MARK: - indentifier helper

--- a/Sources/TPTweak/TPTweakViewController.swift
+++ b/Sources/TPTweak/TPTweakViewController.swift
@@ -272,7 +272,7 @@ public final class TPTweakViewController: UIViewController {
         
         // setup search
         navigationItem.searchController = searchController
-        navigationItem.hidesSearchBarWhenScrolling = true
+        navigationItem.hidesSearchBarWhenScrolling = !(TPTweakEntry._internal_tptweak_always_show_search_bar.getValue(Bool.self) ?? false)
         
         // register gesture
         navigationController?.navigationBar.isUserInteractionEnabled = true
@@ -332,7 +332,7 @@ public final class TPTweakViewController: UIViewController {
                 
                 return value
             } else {
-                return entry.cell
+                return entry.section
             }
         }
         
@@ -396,6 +396,7 @@ extension TPTweakViewController {
         let entries: [TPTweakEntry] = [
             ._internal_tptweak_layout,
             ._internal_tptweak_isMinimizable,
+            ._internal_tptweak_always_show_search_bar,
             ._internal_tptweak_peepOpacity,
             .clearCache
         ]


### PR DESCRIPTION
Add a new tweak entry to control search bar visibility behavior. The search bar can now be configured to remain visible while scrolling through the tweak list.