### PR TITLE
build: add Makefile with bundle and publish targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+bundle:
+	@bundle install
+.PHONY: bundle
+
+publish: bundle
+	@bundle exec pod trunk push TPTweak.podspec --allow-warnings
+.PHONY: publish


### PR DESCRIPTION
Add Makefile to simplify common development tasks:
- bundle: install dependencies
- publish: push podspec to trunk with warnings allowed